### PR TITLE
Revised grammar and punctuation

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <a href="#features">Funksjonar</a>
         <a href="#usage">Bruk</a>
         <a href="https://github.com/adalinesimonian/ordbokapi" target="_blank"
-          >GitHub prosjekt</a
+          >GitHub-prosjekt</a
         >
         <a href="https://api.ordbokapi.org/graphql" target="_blank"
           >Apollo Sandbox</a
@@ -37,7 +37,7 @@
               >Prøv det no</a
             >
             <a href="https://github.com/adalinesimonian/ordbokapi" class="btn"
-              >GitHub prosjekt</a
+              >GitHub-prosjekt</a
             >
           </div>
         </div>
@@ -67,7 +67,7 @@
               brukstilfelle.
             </li>
             <li>
-              <strong>Effektiv datahandtering:</strong> GraphQL spørjespråk for
+              <strong>Effektiv datahandtering:</strong> GraphQL-spørjespråk for
               å henta nøyaktig den informasjonen du treng.
             </li>
           </ul>
@@ -77,7 +77,7 @@
 
     <section id="usage" class="jumbotron">
       <div class="container">
-        <h2>Korleis å bruka APIet</h2>
+        <h2>Korleis bruka APIet</h2>
         <div class="text-content">
           <p>
             Akkurat no er Ordbok API i ein utviklingsfase og kan vera ustabil.
@@ -87,11 +87,11 @@
           </p>
           <ol>
             <li>
-              <strong>Besøk endpoint:</strong> Gå til
+              <strong>Besøk endepunkt:</strong> Gå til
               <a href="https://api.ordbokapi.org/graphql">Apollo Sandbox</a>.
             </li>
             <li>
-              <strong>Test førespurnader:</strong> Bruk sandboxen til å gjera
+              <strong>Test førespurnader:</strong> Bruk sandkassa til å gjera
               førespurnader og sjå responsane.
             </li>
             <li>


### PR DESCRIPTION
- Changed some instances where compound words have a space instead of a dash.
- Removed an instance of the infinitive marker where it shouldn't be used.
- Changed *endpoint* and *sandbox* to Norwegian equivalents in instances where they are clearly used as a term, rather than as part of a proper noun.

---

this is like peak Hacktoberfest PR from a snotty GitHub kid, I'm sorry :woozy_face: 
